### PR TITLE
Leonhardplatz connection permissions

### DIFF
--- a/brunswick/miv/netpatch/patch.con.xml
+++ b/brunswick/miv/netpatch/patch.con.xml
@@ -526,7 +526,7 @@
    
    <!-- Leonhardplatz -->
     <connection from="625058945" fromLane="0" to="291757763#5" toLane="0"/>
-    <connection from="625058945" fromLane="0" to="563616437#0" toLane="0"/>
+    <connection from="625058945" fromLane="0" to="563616437#0" toLane="0" allow="emergency authority bus tram"/>
     <connection from="625058945" fromLane="0" to="5058977#1" toLane="0"/>
     <connection from="320364657#0" fromLane="0" to="23295226#2" toLane="0"/>
     <connection from="320364657#0" fromLane="1" to="5058977#1" toLane="0"/>


### PR DESCRIPTION
Leonhardplatz outbound connection (Leonhardstraße west > east) did not allow trams before. The connection patch file has been updated with the permissions "emergency authority tram bus".

_There are more strange connections at Leonhardplatz which cannot be taken in reality but which don't harm either (like left turn from Leonhardplatz into Leonhardstraße from tram track to lane without track). However they didn't disappear after adding a delete element in the path file?!_